### PR TITLE
Updates clamp() upon resizing of the viewport

### DIFF
--- a/src/clamp-zoom.js
+++ b/src/clamp-zoom.js
@@ -1,6 +1,6 @@
 const Plugin = require('./plugin')
 
-module.exports = class ClampZoon extends Plugin
+module.exports = class ClampZoom extends Plugin
 {
     /**
      * @param {object} [options]
@@ -20,9 +20,9 @@ module.exports = class ClampZoon extends Plugin
 
     resize()
     {
-        clamp()
+        this.clamp()
     }
-    
+
     clamp()
     {
         let width = this.parent.worldScreenWidth

--- a/src/clamp-zoom.js
+++ b/src/clamp-zoom.js
@@ -18,6 +18,11 @@ module.exports = class ClampZoon extends Plugin
         this.maxHeight = options.maxHeight
     }
 
+    resize()
+    {
+        clamp()
+    }
+    
     clamp()
     {
         let width = this.parent.worldScreenWidth

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -573,6 +573,7 @@ module.exports = class Viewport extends Loop
     /**
      * add a hitArea to the container -- useful when your container contains empty spaces that you'd like to drag or pinch
      * @param {PIXI.Rectangle} [rect] if no rect is provided, it will use the value of container.getBounds()
+     * @return {Viewport} this
      */
     hitArea(rect)
     {
@@ -586,6 +587,7 @@ module.exports = class Viewport extends Loop
      * @param {number} y
      * @param {object} [options]
      * @param {number} [options.speed=1] speed (in world pixels/ms) to snap to location
+     * @return {Viewport} this
      */
     snap(x, y, options)
     {
@@ -599,6 +601,7 @@ module.exports = class Viewport extends Loop
      * @param {object} [options]
      * @param {number} [options.speed=0] to follow in pixels/frame
      * @param {number} [options.radius] radius (in world coordinates) of center circle where movement is allowed without moving the viewport
+     * @return {Viewport} this
      */
     follow(target, options)
     {
@@ -616,6 +619,7 @@ module.exports = class Viewport extends Loop
      * @param {number} [options.minHeight] clamp minimum height
      * @param {number} [options.maxWidth] clamp maximum width
      * @param {number} [options.maxHeight] clamp maximum height
+     * @return {Viewport} this
      */
     wheel(options)
     {
@@ -623,6 +627,16 @@ module.exports = class Viewport extends Loop
         return this
     }
 
+    /**
+     * enable clamping of zoom to constraints
+     * NOTE: screenWidth, screenHeight, worldWidth, and worldHeight needs to be set for this to work properly
+     * @param {object} [options]
+     * @param {number} [options.minWidth] minimum width
+     * @param {number} [options.minHeight] minimum height
+     * @param {number} [options.maxWidth] maximum width
+     * @param {number} [options.maxHeight] maximum height
+     * @return {Viewport} this
+     */
     clampZoom(options)
     {
         this.plugins['clamp-zoom'] = new ClampZoom(this, options)

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -99,11 +99,12 @@ module.exports = class Viewport extends Loop
             this.worldWidth = worldWidth
             this.worldHeight = worldHeight
         }
-        for (let plugin of this.plugins)
+
+        for (let type of PLUGIN_ORDER)
         {
-            if (plugin)
+            if (this.plugins[type])
             {
-                plugin.resize()
+                this.plugins[type].resize()
             }
         }
     }


### PR DESCRIPTION
This is important so that if the window size is changed, the viewport maintains its contraints.
e.g. If the viewport is at its max constraints and the window size increases, the viewport should clamp to those max contraints rather than allow the viewport to show more of the world.