### PR TITLE
Fixed 'drag-end' firing prematurely

### DIFF
--- a/src/drag.js
+++ b/src/drag.js
@@ -57,12 +57,12 @@ module.exports = class Drag extends Plugin
 
     up()
     {
-        if (this.last)
+        if (this.last && && this.moved)
         {
             this.parent.emit('drag-end', this.parent)
-            this.last = null
             this.moved = false
         }
+        this.last = null
     }
 
     resume()


### PR DESCRIPTION
The 'drag-end' event would fire upon pressing and releasing the mouse/finger from the screen without actually dragging or having fired the 'drag-start' event first. This fixes that.

_P.S. Lovin' the events system!_