### PR TITLE
Some bug fixes

### DIFF
--- a/src/snap-zoom.js
+++ b/src/snap-zoom.js
@@ -50,7 +50,7 @@ module.exports = class SnapZoom extends Plugin
             parent.container.scale.y = this.y_scale
             if (this.removeOnComplete)
             {
-                this.parent.removePlugin('fit')
+                this.parent.removePlugin('snap-zoom')
             }
         }
     }

--- a/src/snap.js
+++ b/src/snap.js
@@ -51,13 +51,17 @@ module.exports = class Snap extends Plugin
     {
         if (!this.center)
         {
-            this.targetX = this.parent.container.scale.x * (this.parent.worldScreenWidth / 2 - this.originalTargetX)
-            this.targetY = this.parent.container.scale.y * (this.parent.worldScreenHeight / 2 - this.originalTargetY)
-            this.snapping = null
+            /* Finds target center based on the given originalTarget point (the top left corner)
+             * DOES NOT WORK WHEN the snap-zoom plugin is working simultaneously because this.parent.container.scale.x and y are
+             * constantly changing, therefore worldScreenWidth and worldScreenHeight are constantly changing, and the pixi-ease
+             * library does not support constantly changing values
+             */
             this.originalCenter = this.parent.center
+            this.targetX = this.parent.worldScreenWidth / 2 + this.originalTargetX
+            this.targetY = this.parent.worldScreenHeight / 2 + this.originalTargetY
         }
     }
-
+    
     down()
     {
         this.snapping = null
@@ -102,7 +106,6 @@ module.exports = class Snap extends Plugin
                 if (this.removeOnComplete)
                 {
                     this.parent.removePlugin('snap')
-                    console.log('snap-end')
                 }
                 this.parent.emit('snap-end', this.parent )
                 this.snapping = null

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -13,7 +13,7 @@ const SnapZoom = require('./snap-zoom')
 const Follow = require('./follow')
 const Wheel = require('./wheel')
 
-const PLUGIN_ORDER = ['drag', 'pinch', 'wheel', 'follow', 'decelerate', 'bounce', 'snap', 'snap-zoom', 'clamp-zoom', 'clamp']
+const PLUGIN_ORDER = ['drag', 'pinch', 'wheel', 'follow', 'decelerate', 'bounce', 'snap-zoom', 'clamp-zoom', 'snap', 'clamp']
 
 module.exports = class Viewport extends Loop
 {


### PR DESCRIPTION
- *snap-zoom* removeOnComplete option now works
- *snap-zoom* can now run simultaneously with *snap* when `option.center = true` for *snap* (See #19. This bug existed previously and is not introduced by these modifications).