### PR TITLE
Fixes typescript definition issues.

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -242,28 +242,42 @@ declare class Viewport extends PIXI.Container {
   mouseEdges(options?: MouseEdgesOptions): this;
 
   // Events
-  // @ts-ignore Needed because of incompatible override of Container.on()
+  on(
+    event: "added" | "removed",
+    fn: (container: PIXI.Container) => void,
+    context?: any
+  ): this;
+  // Events
+  on(
+    event: PIXI.interaction.InteractionEventTypes,
+    fn: (event: PIXI.interaction.InteractionEvent) => void,
+    context?: any
+  ): this;
   on(
     event: ViewportEventType,
     fn: (viewport: Viewport) => void,
     context?: any
   ): this;
-  // @ts-ignore Needed because of incompatible override of Container.on()
   on(
     event: ViewportClickEventType,
     fn: (data: ViewportClickEventData) => void,
     context?: any
   ): this;
-  // @ts-ignore Needed because of incompatible override of Container.on()
   on(
     event: ViewportWheelEventType,
     fn: (data: ViewportWheelEventData) => void,
     context?: any
   ): this;
 
+  listeners(event: string | symbol): Function[];
+  listeners(event: string | symbol, exists: boolean): boolean;
+
+  /**
+   * Do not use. This is in fact a protected method.
+   */
+  listeners(div: HTMLElement): void;
+
   // Protected/Private methods
-  // @ts-ignore Needed because of incompatible override of Container.listeners()
-  protected listeners(div: HTMLElement): void;
   protected resizePlugins(): void;
   protected down(e: UIEvent): void;
   protected checkThreshold(change: number): void;


### PR DESCRIPTION
`on` and `listeners` overridden methods should not cause any more troubles for Typescript users.

Tested on bare bones example provided here: https://github.com/davidfig/pixi-viewport/issues/63#issuecomment-413350949

Fixes: #63 