### PR TITLE
Fix for destroy called with options

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -97,9 +97,9 @@ class Viewport extends PIXI.Container
     /**
      * overrides PIXI.Container's destroy to also remove the 'wheel' and PIXI.Ticker listeners
      */
-    destroy()
+    destroy(options)
     {
-        super.destroy()
+        super.destroy(options)
         this.removeListeners()
     }
 


### PR DESCRIPTION
As destroy method supports `options` param, we need to make sure to pass
provided options to the super call to maintain their cascading behavior.

A quote from the pixi.js documentation:
> children	boolean	false	optional
> if set to true, all the children will have their destroy method called as well.
> 'options' will be passed on to those calls.