### PR TITLE
Export internal types

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,178 +1,177 @@
-type DirectionType = "all" | "x" | "y";
-
-type UnderflowType = "center" | "top" | "left" | "right" | "bottom" | string;
-
-type SidesType = "all" | "horizontal" | "vertical" | string;
-
-type PluginType =
-  | "bounce"
-  | "clamp-zoom"
-  | "clamp"
-  | "decelerate"
-  | "drag"
-  | "follow"
-  | "mouse-edges"
-  | "pinch"
-  | "snap"
-  | "snap-zoom"
-  | "wheel";
-
-type ViewportEventType =
-  | "pinch-start"
-  | "pinch-end"
-  | "snap-start"
-  | "snap-end"
-  | "snap-zoom-start"
-  | "snap-zoom-end"
-  | "bounce-x-start"
-  | "bounce-x-end"
-  | "bounce-y-start"
-  | "bounce-y-end"
-  | "wheel-scroll"
-  | "mouse-edge-start"
-  | "mouse-edge-end"
-  | "moved"
-  | "zoomed";
-
-type ViewportClickEventType = "clicked" | "drag-start" | "drag-end";
-
-type ViewportWheelEventType = "wheel";
-
-interface ViewportOptions {
-  divWheel?: HTMLElement;
-  forceHitArea?:
-    | PIXI.Rectangle
-    | PIXI.Circle
-    | PIXI.Ellipse
-    | PIXI.Polygon
-    | PIXI.RoundedRectangle;
-  interaction?: PIXI.interaction.InteractionManager;
-  screenHeight?: number;
-  screenWidth?: number;
-  threshold?: number;
-  ticker?: PIXI.ticker.Ticker;
-  worldHeight?: number;
-  worldWidth?: number;
-}
-
-interface DragOptions {
-  direction?: DirectionType;
-  wheel?: boolean;
-  wheelScroll?: number;
-  reverse?: boolean;
-  underflow?: UnderflowType;
-}
-
-interface ClampOptions {
-  left?: boolean | number;
-  right?: boolean | number;
-  top?: boolean | number;
-  bottom?: boolean | number;
-  direction?: DirectionType;
-  underflow?: UnderflowType;
-}
-
-interface DecelerateOptions {
-  friction?: number;
-  bounce?: number;
-  minSpeed?: number;
-}
-
-interface BounceOptions {
-  sides?: SidesType;
-  friction?: number;
-  time?: number;
-  ease?: string | Function;
-  underflow: UnderflowType;
-}
-
-interface PinchOptions {
-  percent?: number;
-  noDrag?: boolean;
-  center?: PIXI.Point;
-}
-
-interface SnapOptions {
-  topLeft?: boolean;
-  friction?: number;
-  time?: number;
-  ease?: string | Function;
-  interrupt?: boolean;
-  removeOnComplete?: boolean;
-  removeOnInterrupt?: boolean;
-  forceStart?: boolean;
-}
-
-interface FollowOptions {
-  speed?: number;
-  radius?: number;
-}
-
-interface WheelOptions {
-  percent?: number;
-  reverse?: boolean;
-  center?: PIXI.Point;
-}
-
-interface ClampZoomOptions {
-  minWidth?: number;
-  minHeight?: number;
-  maxWidth?: number;
-  maxHeight?: number;
-}
-
-interface MouseEdgesOptions {
-  radius?: number;
-  distance?: number;
-  top?: number;
-  bottom?: number;
-  left?: number;
-  right?: number;
-  speed?: number;
-  reverse?: boolean;
-  noDecelerate?: boolean;
-  linear?: boolean;
-}
-
-interface SnapZoomOptions {
-  center?: PIXI.Point;
-  ease?: string | Function;
-  forceStart?: boolean;
-  height?: number;
-  interrupt?: boolean;
-  removeOnComplete?: boolean;
-  removeOnInterrupt?: boolean;
-  time?: number;
-  width?: number;
-}
-
-interface OutOfBounds {
-  bottom: boolean;
-  left: boolean;
-  right: boolean;
-  top: boolean;
-}
-
-interface ViewportClickEventData {
-  screen: PIXI.PointLike;
-  viewport: Viewport;
-  world: PIXI.PointLike;
-}
-
-interface ViewportWheelData {
-  dx: number;
-  dy: number;
-  dz: number;
-}
-
-interface ViewportWheelEventData {
-  viewport: Viewport;
-  wheel: ViewportWheelData;
-}
-
 declare namespace Viewport {
+  type DirectionType = "all" | "x" | "y";
 
+  type UnderflowType = "center" | "top" | "left" | "right" | "bottom" | string;
+
+  type SidesType = "all" | "horizontal" | "vertical" | string;
+
+  type PluginType =
+    | "bounce"
+    | "clamp-zoom"
+    | "clamp"
+    | "decelerate"
+    | "drag"
+    | "follow"
+    | "mouse-edges"
+    | "pinch"
+    | "snap"
+    | "snap-zoom"
+    | "wheel";
+
+  type EventType =
+    | "pinch-start"
+    | "pinch-end"
+    | "snap-start"
+    | "snap-end"
+    | "snap-zoom-start"
+    | "snap-zoom-end"
+    | "bounce-x-start"
+    | "bounce-x-end"
+    | "bounce-y-start"
+    | "bounce-y-end"
+    | "wheel-scroll"
+    | "mouse-edge-start"
+    | "mouse-edge-end"
+    | "moved"
+    | "zoomed";
+
+  type ClickEventType = "clicked" | "drag-start" | "drag-end";
+
+  type WheelEventType = "wheel";
+
+  interface Options {
+    divWheel?: HTMLElement;
+    forceHitArea?:
+      | PIXI.Rectangle
+      | PIXI.Circle
+      | PIXI.Ellipse
+      | PIXI.Polygon
+      | PIXI.RoundedRectangle;
+    interaction?: PIXI.interaction.InteractionManager;
+    screenHeight?: number;
+    screenWidth?: number;
+    threshold?: number;
+    ticker?: PIXI.ticker.Ticker;
+    worldHeight?: number;
+    worldWidth?: number;
+  }
+
+  interface DragOptions {
+    direction?: DirectionType;
+    wheel?: boolean;
+    wheelScroll?: number;
+    reverse?: boolean;
+    underflow?: UnderflowType;
+  }
+
+  interface ClampOptions {
+    left?: boolean | number;
+    right?: boolean | number;
+    top?: boolean | number;
+    bottom?: boolean | number;
+    direction?: DirectionType;
+    underflow?: UnderflowType;
+  }
+
+  interface DecelerateOptions {
+    friction?: number;
+    bounce?: number;
+    minSpeed?: number;
+  }
+
+  interface BounceOptions {
+    sides?: SidesType;
+    friction?: number;
+    time?: number;
+    ease?: string | Function;
+    underflow: UnderflowType;
+  }
+
+  interface PinchOptions {
+    percent?: number;
+    noDrag?: boolean;
+    center?: PIXI.Point;
+  }
+
+  interface SnapOptions {
+    topLeft?: boolean;
+    friction?: number;
+    time?: number;
+    ease?: string | Function;
+    interrupt?: boolean;
+    removeOnComplete?: boolean;
+    removeOnInterrupt?: boolean;
+    forceStart?: boolean;
+  }
+
+  interface FollowOptions {
+    speed?: number;
+    radius?: number;
+  }
+
+  interface WheelOptions {
+    percent?: number;
+    reverse?: boolean;
+    center?: PIXI.Point;
+  }
+
+  interface ClampZoomOptions {
+    minWidth?: number;
+    minHeight?: number;
+    maxWidth?: number;
+    maxHeight?: number;
+  }
+
+  interface MouseEdgesOptions {
+    radius?: number;
+    distance?: number;
+    top?: number;
+    bottom?: number;
+    left?: number;
+    right?: number;
+    speed?: number;
+    reverse?: boolean;
+    noDecelerate?: boolean;
+    linear?: boolean;
+  }
+
+  interface SnapZoomOptions {
+    center?: PIXI.Point;
+    ease?: string | Function;
+    forceStart?: boolean;
+    height?: number;
+    interrupt?: boolean;
+    removeOnComplete?: boolean;
+    removeOnInterrupt?: boolean;
+    time?: number;
+    width?: number;
+  }
+
+  interface OutOfBounds {
+    bottom: boolean;
+    left: boolean;
+    right: boolean;
+    top: boolean;
+  }
+
+  interface ClickEventData {
+    screen: PIXI.PointLike;
+    viewport: Viewport;
+    world: PIXI.PointLike;
+  }
+
+  interface WheelData {
+    dx: number;
+    dy: number;
+    dz: number;
+  }
+
+  interface WheelEventData {
+    viewport: Viewport;
+    wheel: WheelData;
+  }
 }
+
 declare class Viewport extends PIXI.Container {
   screenHeight: number;
   screenWidth: number;
@@ -183,11 +182,11 @@ declare class Viewport extends PIXI.Container {
   worldScreenHeight: number;
 
   forceHitArea?:
-    | PIXI.Rectangle
-    | PIXI.Circle
-    | PIXI.Ellipse
-    | PIXI.Polygon
-    | PIXI.RoundedRectangle;
+      | PIXI.Rectangle
+      | PIXI.Circle
+      | PIXI.Ellipse
+      | PIXI.Polygon
+      | PIXI.RoundedRectangle;
 
   center: PIXI.PointLike;
   corner: PIXI.PointLike;
@@ -199,7 +198,7 @@ declare class Viewport extends PIXI.Container {
 
   dirty: boolean;
 
-  constructor(options?: ViewportOptions);
+  constructor(options?: Viewport.Options);
 
   // Public API
   removeListeners(): void;
@@ -226,20 +225,20 @@ declare class Viewport extends PIXI.Container {
   zoom(change: number, center?: boolean): this;
 
   // Plugins
-  removePlugin(type: PluginType): void;
-  pausePlugin(type: PluginType): void;
-  resumePlugin(type: PluginType): void;
-  drag(options?: DragOptions): this;
-  clamp(options?: ClampOptions): this;
-  decelerate(options?: DecelerateOptions): this;
-  bounce(options?: BounceOptions): this;
-  pinch(options?: PinchOptions): this;
-  snap(x: number, y: number, options?: SnapOptions): this;
-  snapZoom(options?: SnapZoomOptions): this;
-  follow(target: PIXI.DisplayObject, options?: FollowOptions): this;
-  wheel(options?: WheelOptions): this;
-  clampZoom(options?: ClampZoomOptions): this;
-  mouseEdges(options?: MouseEdgesOptions): this;
+  removePlugin(type: Viewport.PluginType): void;
+  pausePlugin(type: Viewport.PluginType): void;
+  resumePlugin(type: Viewport.PluginType): void;
+  drag(options?: Viewport.DragOptions): this;
+  clamp(options?: Viewport.ClampOptions): this;
+  decelerate(options?: Viewport.DecelerateOptions): this;
+  bounce(options?: Viewport.BounceOptions): this;
+  pinch(options?: Viewport.PinchOptions): this;
+  snap(x: number, y: number, options?: Viewport.SnapOptions): this;
+  snapZoom(options?: Viewport.SnapZoomOptions): this;
+  follow(target: PIXI.DisplayObject, options?: Viewport.FollowOptions): this;
+  wheel(options?: Viewport.WheelOptions): this;
+  clampZoom(options?: Viewport.ClampZoomOptions): this;
+  mouseEdges(options?: Viewport.MouseEdgesOptions): this;
 
   // Events
   on(
@@ -254,18 +253,18 @@ declare class Viewport extends PIXI.Container {
     context?: any
   ): this;
   on(
-    event: ViewportEventType,
+    event: Viewport.EventType,
     fn: (viewport: Viewport) => void,
     context?: any
   ): this;
   on(
-    event: ViewportClickEventType,
-    fn: (data: ViewportClickEventData) => void,
+    event: Viewport.ClickEventType,
+    fn: (data: Viewport.ClickEventData) => void,
     context?: any
   ): this;
   on(
-    event: ViewportWheelEventType,
-    fn: (data: ViewportWheelEventData) => void,
+    event: Viewport.WheelEventType,
+    fn: (data: Viewport.WheelEventData) => void,
     context?: any
   ): this;
 
@@ -284,7 +283,7 @@ declare class Viewport extends PIXI.Container {
   protected move(e: UIEvent): void;
   protected up(e: UIEvent): void;
   protected handleWheel(e: UIEvent): void;
-  protected OOB(): OutOfBounds;
+  protected OOB(): Viewport.OutOfBounds;
   protected countDownPointers(): number;
   protected getTouchPointers(): number;
   protected _reset(): void;


### PR DESCRIPTION
Related to #78

## What it is about
Expose all defined types in Typescript definitions.
It's possible to access them right from the module.

```
import * as Viewport from 'pixi-viewport'
import {Options} from 'pixi-viewport'

class MyViewport extends Viewport {
  constructor(options?: Options) {
    super(options)
  }
}
```

## How it is achieved

As the diff is not so clean, let me go through the changes in the type definition file:

1. Wrap all types with Viewport namespace (namespace was empty before)
2. Rename all types starting with `Viewport` to the version without this prefix. Such type is now referenced by `Viewport.NameWithoutPrefixHere` - `ViewportOptions` became `Viewport.Options`
3. Rename all type references from Viewport class declaration according to point 2.

/cc @macropp