### PR TITLE
Update index.d.ts

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -54,7 +54,7 @@ declare namespace Viewport {
     screenWidth?: number;
     threshold?: number;
     passiveWheel?: boolean;
-    ticker?: PIXI.ticker.Ticker;
+    ticker?: PIXI.Ticker;
     worldHeight?: number;
     worldWidth?: number;
   }

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -54,7 +54,7 @@ declare namespace Viewport {
     screenWidth?: number;
     threshold?: number;
     passiveWheel?: boolean;
-    ticker?: PIXI.Ticker;
+    ticker?: PIXI.Ticker | PIXI.ticker.Ticker;
     worldHeight?: number;
     worldWidth?: number;
   }


### PR DESCRIPTION
The global ticker seems in version 5.0.0-alpha.3 now to be available under 'PIXI.Ticker' instead of 'PIXI.ticker.Ticker'