### PR TITLE
Incorporates better zoom logic for mac trackpads

### DIFF
--- a/src/wheel.js
+++ b/src/wheel.js
@@ -78,16 +78,9 @@ module.exports = class Wheel extends Plugin
         }
 
         let point = this.parent.getPointerPosition(e)
-        let sign
-        if (this.reverse)
-        {
-            sign = e.deltaY > 0 ? 1 : -1
-        }
-        else
-        {
-            sign = e.deltaY < 0 ? 1 : -1
-        }
-        const change = 1 + this.percent * sign
+        const sign = this.reverse ? -1 : 1
+        const step = sign * -e.deltaY * (e.deltaMode ? 120 : 1) / 500
+        const change = Math.pow(2, (1 + this.percent) * step)
         if (this.smooth)
         {
             const original = {


### PR DESCRIPTION
Fixes https://github.com/davidfig/pixi-viewport/issues/119

This is the logic d3-zoom uses for its scroll wheel support. I tested on a Mac trackpad and Windows 10 with a SteelSeries Sensei mouse.

Somewhat related, your demo page has the "bounce" plugin on by default, and 100% honest the first time I looked at the demo I didn't realize and thought pixi-viewport was super buggy 😢 I would personally suggest turning that off to avoid confusing people in the demo, but it's obviously your call so I'm just suggesting it.