### PR TITLE
Add missing screenHeight property to types

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -192,6 +192,7 @@ interface ZoomedEventData
 export declare class Viewport extends PIXI.Container
 {
     screenWidth: number
+    screenHeight: number
 
     worldHeight: number
     worldWidth: number


### PR DESCRIPTION
It got lost in https://github.com/davidfig/pixi-viewport/commit/3198d6ab2cade7df47b82699415258bd2f36c515