### PR TITLE
Add missing getVisibleBounds method to types

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -241,7 +241,7 @@ export declare class Viewport extends PIXI.Container
     zoomPercent(percent: number, center?: boolean): this
     zoom(change: number, center?: boolean): this
 
-    // getVisibleBounds(): Viewport.Bounds
+    getVisibleBounds(): Bounds
 
     // Plugins
     plugins: PluginManager


### PR DESCRIPTION
It got removed in [#3198d6ab2cade7df47b82699415258bd2f36c515](https://github.com/davidfig/pixi-viewport/commit/3198d6ab2cade7df47b82699415258bd2f36c515)