### PR TITLE
use reset from plugins instead manage in plugin-manager

### DIFF
--- a/src/plugin-manager.js
+++ b/src/plugin-manager.js
@@ -75,26 +75,9 @@ export class PluginManager
      */
     reset()
     {
-        if (this.plugins['bounce'])
+        for (let plugin of this.list)
         {
-            this.plugins['bounce'].reset()
-            this.plugins['bounce'].bounce()
-        }
-        if (this.plugins['decelerate'])
-        {
-            this.plugins['decelerate'].reset()
-        }
-        if (this.plugins['snap'])
-        {
-            this.plugins['snap'].reset()
-        }
-        if (this.plugins['clamp'])
-        {
-            this.plugins['clamp'].update()
-        }
-        if (this.plugins['clamp-zoom'])
-        {
-            this.plugins['clamp-zoom'].clamp()
+            plugin.reset();
         }
     }
 

--- a/src/plugins/bounce.js
+++ b/src/plugins/bounce.js
@@ -237,6 +237,7 @@ export class Bounce extends Plugin
 
     reset()
     {
-        this.toX = this.toY = null
+        this.toX = this.toY = null;
+        this.bounce();
     }
 }

--- a/src/plugins/clamp-zoom.js
+++ b/src/plugins/clamp-zoom.js
@@ -78,4 +78,9 @@ export class ClampZoom extends Plugin
             this.parent.emit('zoomed', { viewport: this.parent, type: 'clamp-zoom' })
         }
     }
+
+    reset()
+    {
+        this.clamp();
+    }
 }

--- a/src/plugins/clamp.js
+++ b/src/plugins/clamp.js
@@ -198,4 +198,9 @@ export class Clamp extends Plugin
             }
         }
     }
+
+    reset() 
+    {
+        this.update();
+    }
 }


### PR DESCRIPTION
at the moment using of reset is organized directly in the plugin-manager and not using the reset of plugin selfe. so it is only workling with the plugins which are included, else i also have to overwritte the plugin-manager.