### PR TITLE
fix(typings): add MovedEventType type declaration

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -9,6 +9,7 @@ type ClickEventType = 'clicked' | 'drag-start' | 'drag-end'
 type WheelEventType = 'wheel'
 type ZoomedEventType = 'zoomed'
 type ZoomedEventSourceType = 'clamp-zoom' | 'pinch' | 'wheel'
+type MovedEventType = 'moved'
 type MovedEventSourceType = 'bounce-x' | 'bounce-y' | 'clamp-x' | 'clamp-y' | 'decelerate' | 'drag' | 'wheel' | 'follow' | 'mouse-edges' | 'pinch' | 'snap'
 type MouseButtonsType = 'all' | 'left' | 'middle' | 'right' | string
 
@@ -302,6 +303,11 @@ export declare class Viewport extends PIXI.Container
     on(
         event: ZoomedEventType,
         fn: (data: ZoomedEventData) => void,
+        context?: any
+    ): this
+    on(
+        event: MovedEventType,
+        fn: (data: MovedEventData) => void,
         context?: any
     ): this
 


### PR DESCRIPTION
I found a declaration for MovedEventData that was not used anywhere. 
This one will fix it.