### PR TITLE
Mark viewport dirty after resizing

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -246,6 +246,7 @@ export class Viewport extends PIXI.Container
             this._worldHeight = worldHeight
         }
         this.plugins.resize()
+        this.dirty = true
     }
 
     /**


### PR DESCRIPTION
The viewport is currently not marked dirty when only size is changed, so content gets stretched until next render.