### PR TITLE
Fix calculating pointer position without interaction manager

### DIFF
--- a/src/input-manager.js
+++ b/src/input-manager.js
@@ -192,8 +192,9 @@ export class InputManager
         }
         else
         {
-            point.x = event.clientX
-            point.y = event.clientY
+            const rect = this.viewport.options.divWheel.getBoundingClientRect();
+            point.x = event.clientX - rect.left;
+            point.y = event.clientY - rect.top;
         }
         return point
     }


### PR DESCRIPTION
When canvas is not rendered at [0, 0] in document.body and no
interaction manager is supplied, we need to subtract containing div
position from mouse event coordinates.