### PR TITLE
Add keyToPress and ignoreKeyToPressOnTouch to DragOptions

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -12,6 +12,7 @@ type ZoomedEventSourceType = 'clamp-zoom' | 'pinch' | 'wheel'
 type MovedEventType = 'moved'
 type MovedEventSourceType = 'bounce-x' | 'bounce-y' | 'clamp-x' | 'clamp-y' | 'decelerate' | 'drag' | 'wheel' | 'follow' | 'mouse-edges' | 'pinch' | 'snap'
 type MouseButtonsType = 'all' | 'left' | 'middle' | 'right' | string
+type KeyCodeType = 'ControlRight' | 'ControlLeft' | 'ShiftRight' | 'ShiftLeft' | 'AltRight' | 'AltLeft' | string
 
 interface ViewportOptions
 {
@@ -41,6 +42,8 @@ interface DragOptions
     underflow?: string
     factor?: number
     mouseButtons?: MouseButtonsType
+    keyToPress?: Array<KeyCodeType>
+    ignoreKeyToPressOnTouch?: boolean
 }
 
 interface PinchOptions


### PR DESCRIPTION
We could include [all possible key codes](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code/code_values) as KeyCodeType. But I hope this is enough of a start for the common cases.