### PR TITLE
In type definitions: change string to (string & {}) when in union with literals

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,8 +1,8 @@
 import * as PIXI from 'pixi.js'
 
 type DirectionType = 'all' | 'x' | 'y'
-type UnderflowType = 'center' | 'top' | 'left' | 'right' | 'bottom' | string
-type SidesType = 'all' | 'horizontal' | 'vertical' | string
+type UnderflowType = 'center' | 'top' | 'left' | 'right' | 'bottom' | (string & {})
+type SidesType = 'all' | 'horizontal' | 'vertical' | (string & {})
 type PluginType = 'bounce' | 'clamp-zoom' | 'clamp' | 'decelerate' | 'drag' | 'follow' | 'mouse-edges' | 'pinch' | 'snap' | 'snap-zoom' | 'wheel'
 type EventType = 'pinch-start' | 'pinch-end' | 'snap-start' | 'snap-end' | 'snap-zoom-start' | 'snap-zoom-end' | 'bounce-x-start' | 'bounce-x-end' | 'bounce-y-start' | 'bounce-y-end' | 'wheel-scroll' | 'mouse-edge-start' | 'mouse-edge-end' | 'moved' | 'moved-end' | 'zoomed-end' | 'frame-end'
 type ClickEventType = 'clicked' | 'drag-start' | 'drag-end'
@@ -11,8 +11,8 @@ type ZoomedEventType = 'zoomed'
 type ZoomedEventSourceType = 'clamp-zoom' | 'pinch' | 'wheel'
 type MovedEventType = 'moved'
 type MovedEventSourceType = 'bounce-x' | 'bounce-y' | 'clamp-x' | 'clamp-y' | 'decelerate' | 'drag' | 'wheel' | 'follow' | 'mouse-edges' | 'pinch' | 'snap'
-type MouseButtonsType = 'all' | 'left' | 'middle' | 'right' | string
-type KeyCodeType = 'ControlRight' | 'ControlLeft' | 'ShiftRight' | 'ShiftLeft' | 'AltRight' | 'AltLeft' | string
+type MouseButtonsType = 'all' | 'left' | 'middle' | 'right' | (string & {})
+type KeyCodeType = 'ControlRight' | 'ControlLeft' | 'ShiftRight' | 'ShiftLeft' | 'AltRight' | 'AltLeft' | (string & {})
 
 interface ViewportOptions
 {


### PR DESCRIPTION
Per discussion on https://github.com/davidfig/pixi-viewport/pull/234

[Typescript playground link](https://www.typescriptlang.org/play?#code/PTAEGEEMGcFNQIwC5QBED2tqgHboC6jQAW6A7qPsfOgA74CW6O2DOob+sANtw3C1gAofAE9a8AGqwA5gyygAvKADktAK4BbWgGs2K0AB9VAY3VnNAI1gAnA8ej4bbGUO6xCAN2ShpchcrAAFRoPB7wVPA2WISQOAAmoLTR0Ngm+NwA1NC0kCbwQWAqZhbWdm4eoJ4ATCh+8tjKKgBe5ibEbAwqQkIgEDDwtaAAyqRk2JGgdIzMrOycPHwCcCLi8ABiNuoM+I2qkLS07tD2qug2cTJYpwAUjs44MqAAZKAA3gC+AJQVhABmPk2212SlAwVC7i4lGooBSsQSSRSaQy2Vy+VAhX2h2O3UhoD+QyBOz2Khk6kgnkgBj6VH4lDWoHasBMOgm6HQQA) for testing