### PR TITLE
Update Typescript Definitions for PIXI 5.3.0

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -39,7 +39,7 @@ interface DragOptions
     wheelScroll?: number
     reverse?: boolean
     clampWheel?: boolean | string
-    underflow?: string
+    underflow?: UnderflowType
     factor?: number
     mouseButtons?: MouseButtonsType
     keyToPress?: Array<KeyCodeType>
@@ -59,19 +59,6 @@ interface Bounds
     y: number
     width: number
     height: number
-}
-
-
-interface DragOptions
-{
-    direction?: DirectionType
-    wheel?: boolean
-    wheelScroll?: number
-    reverse?: boolean
-    underflow?: UnderflowType
-    clampWheel?: boolean | string
-    factor?: number
-    mouseButtons?: MouseButtonsType
 }
 
 interface ClampOptions

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -18,7 +18,7 @@ interface ViewportOptions
 {
     divWheel?: HTMLElement
     forceHitArea?: PIXI.Rectangle | PIXI.Circle | PIXI.Ellipse | PIXI.Polygon | PIXI.RoundedRectangle
-    interaction?: PIXI.interaction.InteractionManager
+    interaction?: PIXI.InteractionManager
     screenHeight?: number
     screenWidth?: number
     threshold?: number
@@ -177,7 +177,7 @@ interface OutOfBounds
 
 interface ClickEventData
 {
-    event: PIXI.interaction.InteractionEvent
+    event: PIXI.InteractionEvent
     screen: PIXI.Point
     viewport: Viewport
     world: PIXI.Point
@@ -243,7 +243,7 @@ export declare class Viewport extends PIXI.Container
     toScreen(p: PIXI.Point): PIXI.Point
     toScreen(x: number, y: number): PIXI.Point
 
-    getPointerPosition(event: PIXI.interaction.InteractionEvent): PIXI.Point
+    getPointerPosition(event: PIXI.InteractionEvent): PIXI.Point
     getPointerPosition(event: WheelEvent): PIXI.Point
 
     moveCenter(p: PIXI.Point): this
@@ -287,8 +287,8 @@ export declare class Viewport extends PIXI.Container
     ): this
     // Events
     on(
-        event: PIXI.interaction.InteractionEventTypes,
-        fn: (event: PIXI.interaction.InteractionEvent) => void,
+        event: PIXI.InteractionEventTypes,
+        fn: (event: PIXI.InteractionEvent) => void,
         context?: any
     ): this
     on(
@@ -341,9 +341,9 @@ export declare class Viewport extends PIXI.Container
 export declare class Plugin
 {
     constructor(viewport: Viewport)
-    down(event: PIXI.interaction.InteractionEvent): void
-    up(event: PIXI.interaction.InteractionEvent): void
-    move(event: PIXI.interaction.InteractionEvent): void
+    down(event: PIXI.InteractionEvent): void
+    up(event: PIXI.InteractionEvent): void
+    move(event: PIXI.InteractionEvent): void
     wheel(event: WheelEvent): void
     update(): void
     resize(): void

--- a/src/input-manager.js
+++ b/src/input-manager.js
@@ -57,7 +57,7 @@ export class InputManager
 
     /**
      * handle down events for viewport
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      */
     down(event)
     {
@@ -116,7 +116,7 @@ export class InputManager
 
     /**
      * handle move events for viewport
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      */
     move(event)
     {
@@ -145,7 +145,7 @@ export class InputManager
 
     /**
      * handle up events for viewport
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      */
     up(event)
     {

--- a/src/plugin-manager.js
+++ b/src/plugin-manager.js
@@ -138,7 +138,7 @@ export class PluginManager
     /**
      * handle down for all plugins
      * @private
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      * @returns {boolean}
      */
     down(event)
@@ -157,7 +157,7 @@ export class PluginManager
     /**
      * handle move for all plugins
      * @private
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      * @returns {boolean}
      */
     move(event)
@@ -176,7 +176,7 @@ export class PluginManager
     /**
      * handle up for all plugins
      * @private
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      * @returns {boolean}
      */
     up(event)

--- a/src/plugins/clamp.js
+++ b/src/plugins/clamp.js
@@ -65,7 +65,7 @@ export class Clamp extends Plugin
 
     /**
      * handle move events
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      * @returns {boolean}
      */
     move()

--- a/src/plugins/drag.js
+++ b/src/plugins/drag.js
@@ -117,7 +117,7 @@ export class Drag extends Plugin
     }
 
     /**
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      * @returns {boolean}
      */
     checkButtons(event)
@@ -135,7 +135,7 @@ export class Drag extends Plugin
     }
 
     /**
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      * @returns {boolean}
      */
     checkKeyPress(event)
@@ -147,7 +147,7 @@ export class Drag extends Plugin
     }
 
     /**
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      */
     down(event)
     {
@@ -173,7 +173,7 @@ export class Drag extends Plugin
     }
 
     /**
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      */
     move(event)
     {
@@ -219,7 +219,7 @@ export class Drag extends Plugin
     }
 
     /**
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      * @returns {boolean}
      */
     up(event)

--- a/src/plugins/plugin.js
+++ b/src/plugins/plugin.js
@@ -17,7 +17,7 @@ export class Plugin
 
     /**
      * handler for pointerdown PIXI event
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      * @returns {boolean}
      */
     down()
@@ -27,7 +27,7 @@ export class Plugin
 
     /**
      * handler for pointermove PIXI event
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      * @returns {boolean}
      */
     move()
@@ -37,7 +37,7 @@ export class Plugin
 
     /**
      * handler for pointerup PIXI event
-     * @param {PIXI.interaction.InteractionEvent} event
+     * @param {PIXI.InteractionEvent} event
      * @returns {boolean}
      */
     up()


### PR DESCRIPTION
PIXI 5.3.0 removed the `interaction` namespace and put the enclosed stuff in the top-level `PIXI` namespace (https://github.com/pixijs/pixi.js/pull/6681).

This PR fixes the typescript types for PIXI 5.3.0 (though this will then break them for those using older versions of PIXI).

I also removed a duplicate definition of the `DragOptions` type.