### PR TITLE
Added missing @types definitions

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -246,7 +246,9 @@ export declare class Viewport extends PIXI.Container
     lastViewport: any
 
     screenWidthInWorldPixels: number
-    sceenHeightinWorldPixels: number
+    screenHeightInWorldPixels: number
+    screenWorldWidth: number
+    screenWorldHeight: number
 
     constructor(options?: ViewportOptions)
 


### PR DESCRIPTION
screenWorldWidth and screenWorldHeight were missing from type definition.
Also fixed naming of screenHeightInWorldPixels.