### PR TITLE
Added missing bounceBox property and changed the underflow property t…

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -78,7 +78,8 @@ interface BounceOptions {
     friction?: number
     time?: number
     ease?: string | Function
-    underflow: UnderflowType
+    underflow?: UnderflowType
+    bounceBox?: Bounds
 }
 
 interface SnapOptions {


### PR DESCRIPTION
Added missing property 'bounceBox'  and made 'underflow' optional within the Typescript-definition file