### PR TITLE
Fixed Uncaught TypeError when adding keyToPress to drag options

### DIFF
--- a/src/plugins/drag.js
+++ b/src/plugins/drag.js
@@ -69,12 +69,12 @@ export class Drag extends Plugin {
      * @param {array} codes - key codes that can be used to trigger drag event
      */
     handleKeyPresses(codes) {
-        this.parent.addEventListener('keydown', e => {
+        window.addEventListener('keydown', e => {
             if (codes.includes(e.code))
                 this.keyIsPressed = true
         })
 
-        this.parent.addEventListener('keyup', e => {
+        window.addEventListener('keyup', e => {
             if (codes.includes(e.code))
                 this.keyIsPressed = false
         })


### PR DESCRIPTION
Not sure if this is the right fix but it fixed the problem for me. It appears that this.parent has no addEventListener function.

`Uncaught TypeError: this.parent.addEventListener is not a function`

So instead I'm adding the event listener to the window.

I couldn't find where these listeners get removed or I would have added that as well.