### PR TITLE
Fix captured wheel event from a different dom element

### DIFF
--- a/src/input-manager.js
+++ b/src/input-manager.js
@@ -186,6 +186,11 @@ export class InputManager {
             return
         }
 
+        // do not handle events coming from other elements
+        if (this.viewport.options.interaction && this.viewport.options.interaction.interactionDOMElement !== event.target) {
+            return
+        }
+
         // only handle wheel events where the mouse is over the viewport
         const point = this.viewport.toLocal(this.getPointerPosition(event))
         if (this.viewport.left <= point.x && point.x <= this.viewport.right && this.viewport.top <= point.y && point.y <= this.viewport.bottom) {


### PR DESCRIPTION
Scrolling on a DOM element placed over the canvas will trigger the zooming feature. This fix adds a explicit check against the interactionDOMElement defined in the interaction plugin.

Fixes #255