### PR TITLE
Fix toWorld parameter's type

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -240,7 +240,7 @@ export declare class Viewport extends PIXI.Container {
     update(elapsed: number): void
     resize(screenWidth: number, screenHeight: number, worldWidth?: number, worldHeight?: number): void
 
-    toWorld(p: PIXI.Point): PIXI.Point
+    toWorld(p: PIXI.IPointData): PIXI.Point
     toWorld(x: number, y: number): PIXI.Point
     toScreen(p: PIXI.Point): PIXI.Point
     toScreen(x: number, y: number): PIXI.Point


### PR DESCRIPTION
`toWorld()` works with a rectangle (eg the result of getBounds()), but the type `PIXI.Point` doesn't have enough overlap and tsserver raises an error.
We should be able to call `viewport.toWorld(sprite.getBounds())`

When reading the code, I noticed that toWorld is calling pixi.js toLocal, which takes an IPointData as input
```tsx
export interface IPointData
{
    x: number;
    y: number;
}

/**
 * Common interface for points. Both Point and ObservablePoint implement it
 * @memberof PIXI
 * @interface IPointData
 */
```
This would match a rectangle, and hide type errors.
I suppose that docstrings in viewport.js and other types like toScreen param could also be updated the same way.