### PR TITLE
escape 'no-unused-expressions' warning decelerate.js

### DIFF
--- a/src/plugins/decelerate.js
+++ b/src/plugins/decelerate.js
@@ -34,7 +34,7 @@ export class Decelerate extends Plugin {
     }
 
     destroy() {
-        this.parent
+        this.parent.destroy()
     }
 
     down() {


### PR DESCRIPTION
 Line 37:5:  Expected an assignment or function call and instead saw an expression  no-unused-expressions

As far as i understand this work, it might try to destroy parent