### PR TITLE
Visual improvement of minSpeed in Decelerate

### DIFF
--- a/src/plugins/Decelerate.ts
+++ b/src/plugins/Decelerate.ts
@@ -264,13 +264,18 @@ export class Decelerate extends Plugin
         this.timeSinceRelease += elapsed;
 
         // End decelerate velocity once it goes under a certain amount of precision.
-        if (Math.abs(this.x || 0) < this.options.minSpeed)
-        {
-            this.x = 0;
-        }
-        if (Math.abs(this.y || 0) < this.options.minSpeed)
-        {
-            this.y = 0;
+        if (this.x && this.y) {
+            if (Math.abs(this.x) < this.options.minSpeed && Math.abs(this.y) < this.options.minSpeed) {
+                 this.x = 0;
+                 this.y = 0;
+            }
+        } else {
+            if (Math.abs(this.x || 0) < this.options.minSpeed) {
+                this.x = 0;
+            }
+            if (Math.abs(this.y || 0) < this.options.minSpeed) {
+                this.y = 0;
+            }
         }
 
         if (moved)


### PR DESCRIPTION
I added a condition that detects if both axes are active and both are less than minSpeed, if this is correct then I stop them.
This is to make it stop better when minSpeed value is high