### PR TITLE
update toWorld/toScreen types to match what pixi provides

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -508,10 +508,10 @@ export declare class Viewport extends Container {
     get worldHeight(): number;
     set worldHeight(value: number);
     getVisibleBounds(): Rectangle;
-    toWorld(x: number, y: number): Point;
-    toWorld(screenPoint: Point): Point;
-    toScreen(x: number, y: number): Point;
-    toScreen(worldPoint: Point): Point;
+    toWorld<P extends IPointData = Point>(x: number, y: number): P;
+    toWorld<P extends IPointData = Point>(screenPoint: IPointData): P;
+    toScreen<P extends IPointData = Point>(x: number, y: number): P;
+    toScreen<P extends IPointData = Point>(worldPoint: IPointData): P;
     get worldScreenWidth(): number;
     get worldScreenHeight(): number;
     get screenWorldWidth(): number;

--- a/src/Viewport.ts
+++ b/src/Viewport.ts
@@ -1,5 +1,5 @@
 import { Container } from '@pixi/display';
-import { Point, Rectangle } from '@pixi/math';
+import { IPointData, Point, Rectangle } from '@pixi/math';
 import { Ticker } from '@pixi/ticker';
 
 import { InputManager } from './InputManager';
@@ -387,33 +387,31 @@ export class Viewport extends Container
     }
 
     /** Change coordinates from screen to world */
-    public toWorld(x: number, y: number): Point;
+    public toWorld<P extends IPointData = Point>(x: number, y: number): P;
     /** Change coordinates from screen to world */
-    public toWorld(screenPoint: Point): Point;
+    public toWorld<P extends IPointData = Point>(screenPoint: IPointData): P;
 
-    public toWorld(x: number | Point, y?: number): Point
+    public toWorld<P extends IPointData = Point>(x: number | IPointData, y?: number): P
     {
         if (arguments.length === 2)
         {
-            return this.toLocal(new Point(x as number, y));
+            return this.toLocal<P>(new Point(x as number, y));
         }
-
-        return this.toLocal(x as Point);
+        return this.toLocal<P>(x as IPointData);
     }
 
     /** Change coordinates from world to screen */
-    public toScreen(x: number, y: number): Point;
+    public toScreen<P extends IPointData = Point>(x: number, y: number): P
     /** Change coordinates from world to screen */
-    public toScreen(worldPoint: Point): Point;
+    public toScreen<P extends IPointData = Point>(worldPoint: IPointData): P
 
-    public toScreen(x: number | Point, y?: number): Point
+    public toScreen<P extends IPointData = Point>(x: number | IPointData, y?: number): P
     {
         if (arguments.length === 2)
         {
-            return this.toGlobal(new Point(x as number, y));
+            return this.toGlobal<P>(new Point(x as number, y));
         }
-
-        return this.toGlobal(x as Point);
+        return this.toGlobal<P>(x as IPointData);
     }
 
     /** Screen width in world coordinates */


### PR DESCRIPTION
- Removes need to cast to `Point` when calling `toScreen`/`toWorld`
- Allows the return type to be changed using the generic

Reference: https://github.com/pixijs/pixijs/blob/bb47818dfa2c388f8adb6dbb3a8f32fdfb1e72a0/packages/display/src/DisplayObject.ts#L675