### PR TITLE
Mouse edge distance fix

### DIFF
--- a/src/plugins/MouseEdges.ts
+++ b/src/plugins/MouseEdges.ts
@@ -115,15 +115,15 @@ export class MouseEdges extends Plugin
         {
             this.left = distance;
             this.top = distance;
-            this.right = this.parent.worldScreenWidth - distance;
-            this.bottom = this.parent.worldScreenHeight - distance;
+            this.right = this.parent.screenWidth - distance;
+            this.bottom = this.parent.screenHeight - distance;
         }
         else if (!this.options.radius)
         {
             this.left = this.options.left;
             this.top = this.options.top;
-            this.right = this.options.right === null ? null : this.parent.worldScreenWidth - this.options.right;
-            this.bottom = this.options.bottom === null ? null : this.parent.worldScreenHeight - this.options.bottom;
+            this.right = this.options.right === null ? null : this.parent.screenWidth - this.options.right;
+            this.bottom = this.options.bottom === null ? null : this.parent.screenHeight - this.options.bottom;
         }
     }
 


### PR DESCRIPTION
The wrong variable was used, causing strange behavior when using MouseEdge with distance, for Right and Bottom. 

This issue was mentioned here: https://github.com/davidfig/pixi-viewport/issues/263

@davidfig 