### PR TITLE
fix event listener leak in drag plugin

### DIFF
--- a/src/PluginManager.ts
+++ b/src/PluginManager.ts
@@ -70,6 +70,14 @@ export class PluginManager
      */
     public add(name: string, plugin: Plugin, index: number = PLUGIN_ORDER.length)
     {
+
+        const oldPlugin = this.plugins[name];
+
+        if (oldPlugin)
+        {
+            oldPlugin.destroy();
+        }
+
         this.plugins[name] = plugin;
 
         const current = PLUGIN_ORDER.indexOf(name);
@@ -157,6 +165,9 @@ export class PluginManager
     /** removes all installed plugins */
     public removeAll(): void
     {
+        this.list.forEach((plugin) => {
+            plugin.destroy();
+        })
         this.plugins = {};
         this.sort();
     }
@@ -170,6 +181,7 @@ export class PluginManager
     {
         if (this.plugins[name])
         {
+            this.plugins[name]?.destroy();
             delete this.plugins[name];
             this.viewport.emit(`${name}-remove`);
             this.sort();

--- a/src/plugins/Drag.ts
+++ b/src/plugins/Drag.ts
@@ -160,6 +160,9 @@ export class Drag extends Plugin
     /** The ID of the pointer currently panning the viewport. */
     protected current?: number;
 
+    /** Array of event-handlers for window */
+    private windowEventHandlers: Array<{event: string, handler: (e: any) => void}> = new Array();
+
     /**
      * This is called by {@link Viewport.drag}.
      */
@@ -190,17 +193,31 @@ export class Drag extends Plugin
      */
     protected handleKeyPresses(codes: string[]): void
     {
-        window.addEventListener('keydown', (e) =>
-        {
+        const keydownHandler = (e: KeyboardEvent) => {
             if (codes.includes(e.code))
             { this.keyIsPressed = true; }
-        });
+        }
 
-        window.addEventListener('keyup', (e) =>
-        {
+        const keyupHandler = (e: KeyboardEvent) => {
             if (codes.includes(e.code))
             { this.keyIsPressed = false; }
-        });
+        }
+
+        this.addWindowEventHandler("keyup", keyupHandler);
+        this.addWindowEventHandler("keydown", keydownHandler);
+    }
+
+    private addWindowEventHandler(event: string, handler: (e: any) => void): void
+    {
+        window.addEventListener(event, handler);
+        this.windowEventHandlers.push({event, handler});
+    }
+
+    public override destroy(): void
+    {
+        this.windowEventHandlers.forEach(({event, handler}) => {
+            window.removeEventListener(event, handler);
+        })
     }
 
     /**


### PR DESCRIPTION
Hi! I tried to implement fix for event listeners leak, like was mentioned [here](https://github.com/davidfig/pixi-viewport/issues/402#issuecomment-1273796162)

I implemented the easiest approach, because I think that handling keyboard events inside plugins is not the best practice, because if you use Drag and Wheel plugin at the same time, you should handle keyboard events yourself :(

I wanted to use Ctrl+scroll for zoom and just just scroll for scrolling the viewport, and I cant figure out how to do that without handling keyboard events myself.