### PR TITLE
PIXI v7.2 deprecation interactive

### DIFF
--- a/src/InputManager.ts
+++ b/src/InputManager.ts
@@ -39,7 +39,7 @@ export class InputManager
     /** Add input listeners */
     private addListeners()
     {
-        this.viewport.interactive = true;
+        this.viewport.eventMode = 'static';
         if (!this.viewport.forceHitArea)
         {
             this.viewport.hitArea = new Rectangle(0, 0, this.viewport.worldWidth, this.viewport.worldHeight);


### PR DESCRIPTION
On PIXI v7.2.0 (https://github.com/pixijs/pixijs/releases/tag/v7.2.0),
`interactive` has been changed to `eventMode`, 
I just sent this modification to prevent depraction notice from showing