### PR TITLE
Update InputManager.ts

### DIFF
--- a/src/InputManager.ts
+++ b/src/InputManager.ts
@@ -39,7 +39,7 @@ export class InputManager
     /** Add input listeners */
     private addListeners()
     {
-        this.viewport.interactive = true;
+        this.viewport.eventMode = 'dynamic';
         if (!this.viewport.forceHitArea)
         {
             this.viewport.hitArea = new Rectangle(0, 0, this.viewport.worldWidth, this.viewport.worldHeight);


### PR DESCRIPTION
fixes a deprecation that was issued from v7.2.0 for pixiJS. interactive layers should be assigned to eventMode = 'none'/'passive'/'auto'/'static'/'dynamic'