### PR TITLE
Update README.md for v5.2 (interactive deprecation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ With your support, I can make pixi-viewport even better! Please consider making 
   <img src="https://opencollective.com/pixi-viewport/donate/button@2x.png?color=blue" width=300 style="margin-top: 0.5rem; display: block"/>
 </a>
 
+## v5.2+
+Moves pixi-viewport to pixi.js v7.2+
+
+NOTE: there is a breaking change since in pixi.js v7.2 `interactive` (boolean) was deprecated in favor of `eventMode`.
+
 ## v5+
 Moves pixi-viewport to pixi.js v7 (thanks [@cuire](https://github.com/cuire)!).
 


### PR DESCRIPTION
In 5.2 viewport's version a breaking change was made, that replaced `interactive` boolean with `eventMode`, which means that people with pixi.js < 7.2 are not able to use v5.2

Seems that those changes should be emphasized in readme.