### PR TITLE
Fix: animate while wheel removeOnInterrupt not work

### DIFF
--- a/src/plugins/Animate.ts
+++ b/src/plugins/Animate.ts
@@ -188,6 +188,16 @@ export class Animate extends Plugin
         }
     }
 
+    public wheel(): boolean
+    {
+        if (this.options.removeOnInterrupt)
+        {
+            this.parent.plugins.remove('animate');
+        }
+
+        return false;
+    }
+
     public down(): boolean
     {
         if (this.options.removeOnInterrupt)


### PR DESCRIPTION
fix #524 When using wheel at the same time as animate, removeOnInterrupt does not work.
add function wheel
