### PR TITLE
Changed behaviour of wheel

### DIFF
--- a/src/plugins/Drag.ts
+++ b/src/plugins/Drag.ts
@@ -485,7 +485,17 @@ export class Drag extends Plugin
         {
             const wheel = this.parent.plugins.get('wheel', true);
 
-            if (!wheel || (!wheel.options.wheelZoom && !event.ctrlKey))
+            if (!wheel
+                || (
+                    (!wheel.options.wheelZoom
+                        || (
+                            wheel.options.wheelZoom
+                            && wheel.options.keyToPress
+                            && !wheel.checkKeyPress()
+                        )
+                    )
+                    && !event.ctrlKey)
+            )
             {
                 const step = event.deltaMode ? this.options.lineHeight : 1;
 

--- a/src/plugins/Wheel.ts
+++ b/src/plugins/Wheel.ts
@@ -287,7 +287,7 @@ export class Wheel extends Plugin
         {
             this.pinch(e);
         }
-        else if ((!this.options.keyToPress || !this.checkKeyPress()) && this.options.wheelZoom)
+        else if ((!this.options.keyToPress || this.checkKeyPress()) && this.options.wheelZoom)
         {
             const point = this.parent.input.getPointerPosition(e);
             const sign = this.options.reverse ? -1 : 1;

--- a/src/plugins/Wheel.ts
+++ b/src/plugins/Wheel.ts
@@ -143,7 +143,7 @@ export class Wheel extends Plugin
         });
     }
 
-    protected checkKeyPress(): boolean
+    public checkKeyPress(): boolean
     {
         return !this.options.keyToPress || this.keyIsPressed;
     }
@@ -283,16 +283,11 @@ export class Wheel extends Plugin
             return false;
         }
 
-        if (!this.checkKeyPress())
-        {
-            return false;
-        }
-
         if (e.ctrlKey && this.options.trackpadPinch)
         {
             this.pinch(e);
         }
-        else if (this.options.wheelZoom)
+        else if ((!this.options.keyToPress || !this.checkKeyPress()) && this.options.wheelZoom)
         {
             const point = this.parent.input.getPointerPosition(e);
             const sign = this.options.reverse ? -1 : 1;


### PR DESCRIPTION
I have changed behaviour because I think it makes more sense. What I'm trying to achieve:
Here is my example

```
viewportRef.
  .drag({ keyToPress: ['Space'] })
  .pinch()
  .decelerate()
  .wheel({
    trackpadPinch: true,        
    smooth: 3,
    keyToPress: [
      'ControlLeft',
       'MetaLeft',
       'AltLeft',
       'ControlRight',
       'MetaRight',
       'AltRight',
    ],
  })
```

if I'm using trackpad I can navigate by viewport + I can do pitch to zoom
if I'm using mouse I should hold space to drag and drop viewport + I can zoom in/out if I hold ctrl/alt/cmd

